### PR TITLE
Add incremental Slack ingestion using LastIngest timestamp

### DIFF
--- a/cmd/kb/cmd_ingest.go
+++ b/cmd/kb/cmd_ingest.go
@@ -537,9 +537,15 @@ func remoteIngest(ctx context.Context, conn connector.Connector, remote string, 
 		return fmt.Errorf("get checksums: %w", err)
 	}
 
+	// Look up the source to get LastIngest for incremental time-based filtering.
+	scanOpts := connector.ScanOptions{Known: known}
+	if src, err := s.GetSource(ctx, conn.Name(), conn.SourceName()); err == nil && src != nil && src.LastIngest != nil {
+		scanOpts.LastIngest = src.LastIngest
+	}
+
 	// Scan for new/changed documents and deleted paths.
 	fmt.Fprintf(os.Stderr, "Scanning %s...\n", conn.Name())
-	docs, deleted, err := conn.Scan(ctx, connector.ScanOptions{Known: known})
+	docs, deleted, err := conn.Scan(ctx, scanOpts)
 	if err != nil {
 		return fmt.Errorf("scan: %w", err)
 	}

--- a/internal/connector/slack.go
+++ b/internal/connector/slack.go
@@ -89,7 +89,16 @@ func (c *SlackConnector) Config(mode string) map[string]string {
 // Scan fetches messages from configured Slack channels and returns them as documents.
 func (c *SlackConnector) Scan(ctx context.Context, opts ScanOptions) ([]model.RawDocument, []string, error) {
 	known := opts.Known
-	oldest := strconv.FormatInt(time.Now().AddDate(0, 0, -c.lookbackDays).Unix(), 10)
+
+	// Determine the oldest timestamp for the API query.
+	// If LastIngest is set (subsequent scan), use it minus a 1-day overlap buffer.
+	// Otherwise (first scan), fall back to the configured lookback window.
+	var oldest string
+	if opts.LastIngest != nil {
+		oldest = strconv.FormatInt(opts.LastIngest.AddDate(0, 0, -1).Unix(), 10)
+	} else {
+		oldest = strconv.FormatInt(time.Now().AddDate(0, 0, -c.lookbackDays).Unix(), 10)
+	}
 
 	var docs []model.RawDocument
 	for _, channelID := range c.channelIDs {

--- a/internal/connector/slack_test.go
+++ b/internal/connector/slack_test.go
@@ -921,6 +921,96 @@ func TestSlackBuildDocumentsUsesContext(t *testing.T) {
 	}
 }
 
+func TestSlackIncrementalScanWithLastIngest(t *testing.T) {
+	// Set LastIngest to 7 days ago. The oldest param should be ~8 days ago (7 days minus 1-day buffer).
+	lastIngest := time.Now().Add(-7 * 24 * time.Hour)
+
+	mock := &slackMockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: channelInfoJSON("incremental")},
+			{statusCode: 200, body: historyJSON(nil, "")},
+		},
+	}
+
+	c := NewSlackConnector("xoxb-test", []string{"CINC"}, "")
+	c.httpClient = mock
+
+	_, _, err := c.Scan(context.Background(), ScanOptions{LastIngest: &lastIngest})
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	// Verify the history request uses an oldest param ~8 days ago (LastIngest minus 1-day buffer).
+	for _, req := range mock.requests {
+		if strings.Contains(req.URL.String(), "conversations.history") {
+			reqURL := req.URL.String()
+			if !strings.Contains(reqURL, "oldest=") {
+				t.Error("expected oldest parameter in history request")
+				continue
+			}
+			for _, part := range strings.Split(reqURL, "&") {
+				if strings.HasPrefix(part, "oldest=") {
+					val := strings.TrimPrefix(part, "oldest=")
+					ts, err := strconv.ParseInt(val, 10, 64)
+					if err != nil {
+						t.Errorf("failed to parse oldest: %v", err)
+						continue
+					}
+					expected := lastIngest.AddDate(0, 0, -1).Unix()
+					diff := ts - expected
+					if diff < -60 || diff > 60 {
+						t.Errorf("oldest timestamp off by more than 60s: got %d, expected ~%d (LastIngest minus 1-day buffer)", ts, expected)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSlackFirstScanNoLastIngest(t *testing.T) {
+	// Zero LastIngest should fall back to the default 90-day lookback window.
+	mock := &slackMockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: channelInfoJSON("first-scan")},
+			{statusCode: 200, body: historyJSON(nil, "")},
+		},
+	}
+
+	c := NewSlackConnector("xoxb-test", []string{"CFIRST"}, "")
+	c.httpClient = mock
+
+	_, _, err := c.Scan(context.Background(), ScanOptions{})
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	// Verify the history request uses an oldest param ~90 days ago.
+	for _, req := range mock.requests {
+		if strings.Contains(req.URL.String(), "conversations.history") {
+			reqURL := req.URL.String()
+			if !strings.Contains(reqURL, "oldest=") {
+				t.Error("expected oldest parameter in history request")
+				continue
+			}
+			for _, part := range strings.Split(reqURL, "&") {
+				if strings.HasPrefix(part, "oldest=") {
+					val := strings.TrimPrefix(part, "oldest=")
+					ts, err := strconv.ParseInt(val, 10, 64)
+					if err != nil {
+						t.Errorf("failed to parse oldest: %v", err)
+						continue
+					}
+					expected := time.Now().AddDate(0, 0, -defaultLookbackDays).Unix()
+					diff := ts - expected
+					if diff < -60 || diff > 60 {
+						t.Errorf("oldest timestamp off by more than 60s: got %d, expected ~%d (90-day lookback)", ts, expected)
+					}
+				}
+			}
+		}
+	}
+}
+
 func TestSlackNetworkError(t *testing.T) {
 	// Use a mock that returns an error on Do.
 	errMock := &slackMockHTTPClient{

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -120,8 +120,19 @@ func (p *Pipeline) Run(ctx context.Context, conn connector.Connector, opts ...Op
 		}
 	}
 
+	// Look up the source to get LastIngest for incremental time-based filtering.
+	// Skip when Force is set so connectors like Slack scan the full lookback window.
+	scanOpts := connector.ScanOptions{Known: known, Force: opt.Force}
+	if !opt.Force {
+		if src, err := p.store.GetSource(ctx, conn.Name(), conn.SourceName()); err != nil {
+			p.logger.Warn("failed to look up source for incremental scan, falling back to full scan", "error", err)
+		} else if src != nil && src.LastIngest != nil {
+			scanOpts.LastIngest = src.LastIngest
+		}
+	}
+
 	// Scan for new/changed documents and deleted paths.
-	docs, deleted, err := conn.Scan(ctx, connector.ScanOptions{Known: known, Force: opt.Force})
+	docs, deleted, err := conn.Scan(ctx, scanOpts)
 	if err != nil {
 		return nil, fmt.Errorf("scan: %w", err)
 	}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -99,6 +99,8 @@ type MockConnector struct {
 	ConnectorName string
 	Docs          []model.RawDocument
 	RemovedPaths  []string
+	// LastScanOpts captures the ScanOptions from the most recent Scan call.
+	LastScanOpts connector.ScanOptions
 }
 
 var _ connector.Connector = (*MockConnector)(nil)
@@ -108,6 +110,7 @@ func (m *MockConnector) SourceName() string       { return m.ConnectorName }
 func (m *MockConnector) Config(mode string) map[string]string { return map[string]string{} }
 
 func (m *MockConnector) Scan(_ context.Context, opts connector.ScanOptions) ([]model.RawDocument, []string, error) {
+	m.LastScanOpts = opts
 	known := opts.Known
 	// Build the set of currently-known paths for deletion detection.
 	currentPaths := make(map[string]bool)
@@ -622,4 +625,140 @@ func Bad() {
 		t.Fatal("expected at least some fragments to be added despite one failure")
 	}
 	t.Logf("With nil embedding: added=%d (normal was %d)", result2.Added, totalFragments)
+}
+
+func TestPipelinePassesLastIngestToConnector(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	embedder := NewMockEmbedder(embeddingDim)
+	registry := newTestRegistry()
+
+	content := "# Test Doc\n\nSome content.\n"
+	conn := &MockConnector{
+		ConnectorName: "mock",
+		Docs:          []model.RawDocument{makeDoc("docs/test.md", content, checksum(content))},
+	}
+
+	// Register a source with a LastIngest timestamp.
+	lastIngest := time.Now().Add(-24 * time.Hour)
+	err := s.RegisterSource(ctx, model.Source{
+		SourceType: "mock",
+		SourceName: "mock",
+		Config:     map[string]string{},
+		LastIngest: &lastIngest,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSource: %v", err)
+	}
+
+	pipeline := ingest.NewPipeline(s, embedder, registry, 2, nil)
+	_, err = pipeline.Run(ctx, conn)
+	if err != nil {
+		t.Fatalf("Pipeline.Run: %v", err)
+	}
+
+	// Verify that the connector received the LastIngest value.
+	if conn.LastScanOpts.LastIngest == nil {
+		t.Fatal("expected LastIngest to be passed to connector, got nil")
+	}
+	// Allow 1 second tolerance for timestamp comparison.
+	diff := conn.LastScanOpts.LastIngest.Sub(lastIngest)
+	if diff < -time.Second || diff > time.Second {
+		t.Errorf("LastIngest mismatch: got %v, want ~%v", *conn.LastScanOpts.LastIngest, lastIngest)
+	}
+}
+
+func TestPipelineNoLastIngestForNewSource(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	embedder := NewMockEmbedder(embeddingDim)
+	registry := newTestRegistry()
+
+	content := "# New Doc\n\nBrand new content.\n"
+	conn := &MockConnector{
+		ConnectorName: "mock",
+		Docs:          []model.RawDocument{makeDoc("docs/new.md", content, checksum(content))},
+	}
+
+	// Do NOT register a source — simulates first-ever ingestion.
+	pipeline := ingest.NewPipeline(s, embedder, registry, 2, nil)
+	_, err := pipeline.Run(ctx, conn)
+	if err != nil {
+		t.Fatalf("Pipeline.Run: %v", err)
+	}
+
+	// Verify that LastIngest is nil (no previous source record).
+	if conn.LastScanOpts.LastIngest != nil {
+		t.Errorf("expected nil LastIngest for new source, got %v", conn.LastScanOpts.LastIngest)
+	}
+}
+
+func TestPipelineForceSkipsLastIngest(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	embedder := NewMockEmbedder(embeddingDim)
+	registry := newTestRegistry()
+
+	content := "# Force Test\n\nContent for force test.\n"
+	conn := &MockConnector{
+		ConnectorName: "mock",
+		Docs:          []model.RawDocument{makeDoc("docs/force.md", content, checksum(content))},
+	}
+
+	// Register a source with a LastIngest timestamp.
+	forceLastIngest := time.Now().Add(-24 * time.Hour)
+	err := s.RegisterSource(ctx, model.Source{
+		SourceType: "mock",
+		SourceName: "mock",
+		Config:     map[string]string{},
+		LastIngest: &forceLastIngest,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSource: %v", err)
+	}
+
+	// Run with Force — LastIngest should NOT be passed to the connector.
+	pipeline := ingest.NewPipeline(s, embedder, registry, 2, nil)
+	_, err = pipeline.Run(ctx, conn, ingest.Options{Force: true})
+	if err != nil {
+		t.Fatalf("Pipeline.Run: %v", err)
+	}
+
+	if conn.LastScanOpts.LastIngest != nil {
+		t.Errorf("expected nil LastIngest when Force is true, got %v", conn.LastScanOpts.LastIngest)
+	}
+}
+
+func TestPipelineZeroLastIngestSource(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	embedder := NewMockEmbedder(embeddingDim)
+	registry := newTestRegistry()
+
+	content := "# Zero Test\n\nContent for zero LastIngest test.\n"
+	conn := &MockConnector{
+		ConnectorName: "mock",
+		Docs:          []model.RawDocument{makeDoc("docs/zero.md", content, checksum(content))},
+	}
+
+	// Register a source WITHOUT setting LastIngest (zero value).
+	err := s.RegisterSource(ctx, model.Source{
+		SourceType: "mock",
+		SourceName: "mock",
+		Config:     map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("RegisterSource: %v", err)
+	}
+
+	pipeline := ingest.NewPipeline(s, embedder, registry, 2, nil)
+	_, err = pipeline.Run(ctx, conn)
+	if err != nil {
+		t.Fatalf("Pipeline.Run: %v", err)
+	}
+
+	// Source exists but LastIngest is nil — should NOT pass LastIngest to connector.
+	if conn.LastScanOpts.LastIngest != nil {
+		t.Errorf("expected nil LastIngest for source with nil LastIngest, got %v", conn.LastScanOpts.LastIngest)
+	}
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,6 +4,7 @@ package connector
 
 import (
 	"context"
+	"time"
 
 	"github.com/knowledge-broker/knowledge-broker/pkg/model"
 )
@@ -17,6 +18,12 @@ type ScanOptions struct {
 	// Force skips incremental optimizations (e.g. diff-based scan) and
 	// processes all files.
 	Force bool
+
+	// LastIngest is the timestamp of the last successful ingestion for this source.
+	// Connectors that support time-based filtering (e.g., Slack) can use this
+	// to narrow the scan window instead of always fetching the full lookback period.
+	// Nil means no previous ingestion (first scan).
+	LastIngest *time.Time
 }
 
 // Connector pulls documents from a source.


### PR DESCRIPTION
## Summary

Slack ingestion currently scans the full 90-day lookback window on every run, even if the source was ingested an hour ago. The checksum deduplication avoids re-processing unchanged documents, but all the Slack API calls to fetch messages are still made every time. For high-volume channels this is wasteful and slow.

This PR makes Slack ingestion incremental by plumbing the source's `LastIngest` timestamp through to the connector. On subsequent ingestions, the Slack connector now queries only from `LastIngest - 1 day` instead of the full 90-day window, dramatically reducing API calls. The 1-day overlap buffer guards against messages posted near the boundary, daily digest documents that straddle it, and clock skew.

The `LastIngest` field is added to `ScanOptions` at the public connector interface level, so any connector *can* use it, but only Slack does — filesystem, git, and Confluence connectors simply ignore it. The pipeline and remote ingestion paths both look up the source record from the store before scanning. `--force` bypasses the optimization so forced re-ingestion always scans the full window.

## Test plan

New tests cover the Slack connector using `LastIngest` to narrow the query window, falling back to the 90-day default on first scan, the pipeline passing `LastIngest` from the store, the `--force` flag bypassing it, and the edge case where a source exists but has a zero `LastIngest`. All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)