### PR TITLE
Fix database locked error during concurrent access

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -49,9 +49,27 @@ func NewSQLiteStore(dbPath string, embeddingDim int) (*SQLiteStore, error) {
 	return &SQLiteStore{db: db, embeddingDim: embeddingDim}, nil
 }
 
+// schemaReady checks whether the database schema is already initialized and
+// the stored embedding dimension matches. When true, we can skip all write
+// operations in initSchema, avoiding write-lock contention with concurrent
+// writers (e.g. an in-progress ingestion).
+func schemaReady(db *sql.DB, embeddingDim int) bool {
+	var val string
+	err := db.QueryRow("SELECT value FROM metadata WHERE key = 'embedding_dim'").Scan(&val)
+	return err == nil && val == fmt.Sprintf("%d", embeddingDim)
+}
+
 // initSchema runs migrations, creates virtual tables, and validates metadata.
-// All operations are idempotent so safe to retry.
+// All operations are idempotent so safe to retry. If the schema is already
+// fully initialized, only a read is performed (no write lock needed).
 func initSchema(db *sql.DB, embeddingDim int) error {
+	// Fast path: if schema already exists with the correct embedding dim,
+	// skip all writes. This lets read-only callers (e.g. "kb sources list")
+	// open the store without acquiring a write lock.
+	if schemaReady(db, embeddingDim) {
+		return nil
+	}
+
 	// Run schema migrations.
 	if _, err := db.Exec(migrationSQL); err != nil {
 		return fmt.Errorf("run migrations: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -55,6 +55,40 @@ func TestMetadataValidation(t *testing.T) {
 	}
 }
 
+// TestConcurrentOpenDuringWrite verifies that opening a second store handle
+// (e.g. for "kb sources list") succeeds even when another connection holds a
+// long-running write transaction (e.g. ingestion). This is the scenario
+// reported in GitHub issue #12.
+func TestConcurrentOpenDuringWrite(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// First open initializes the schema.
+	s1, err := NewSQLiteStore(dbPath, 4)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	defer s1.Close()
+
+	// Start a long-running write transaction to simulate ingestion.
+	tx, err := s1.db.Begin()
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec("INSERT INTO fragments (id, raw_content, source_type, source_path, source_uri, content_date, file_type, checksum) VALUES ('hold', 'data', 'test', '/x', 'file:///x', '2024-01-01T00:00:00Z', 'txt', 'aaa')"); err != nil {
+		t.Fatalf("insert in tx: %v", err)
+	}
+
+	// Second open should succeed without blocking on the write lock,
+	// because schemaReady sees the metadata via a read and skips writes.
+	s2, err := NewSQLiteStore(dbPath, 4)
+	if err != nil {
+		t.Fatalf("second open while write tx held: %v", err)
+	}
+	s2.Close()
+}
+
 func TestUpsertAndGetFragments(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Closes #12.

`kb sources list` (and other read-only commands) failed with `database is locked` when run during ingestion, because `initSchema` unconditionally ran write statements even when the schema was already set up.

Added a `schemaReady()` read-only check — a single SELECT on the metadata table. If the schema is already initialized with the correct embedding dimension, all writes are skipped entirely.

## Changes

- `internal/store/sqlite.go` — Added `schemaReady()` fast path in `initSchema`
- `internal/store/sqlite_test.go` — Added `TestConcurrentOpenDuringWrite`

## Test plan

- [x] `make test` passes
- [x] New test reproduces the concurrent access scenario
- [ ] Manual: run `kb ingest` on a large repo, simultaneously run `kb sources list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)