### PR TITLE
Fix Ollama embed returning 0 embeddings with retry and input validation

### DIFF
--- a/internal/connector/github_wiki_test.go
+++ b/internal/connector/github_wiki_test.go
@@ -101,8 +101,9 @@ func setupBareWikiRepo(t *testing.T) string {
 	bareDir := filepath.Join(base, "repo.wiki.git")
 	workDir := filepath.Join(base, "work")
 
-	// Create bare repo.
-	run(t, "git", "init", "--bare", bareDir)
+	// Create bare repo with explicit default branch to avoid failures
+	// when global init.defaultBranch is not set.
+	run(t, "git", "init", "--bare", "--initial-branch=main", bareDir)
 
 	// Clone it, add files, push.
 	run(t, "git", "clone", bareDir, workDir)
@@ -118,7 +119,7 @@ func setupBareWikiRepo(t *testing.T) string {
 
 	runIn(t, workDir, "git", "add", "-A")
 	runIn(t, workDir, "git", "commit", "-m", "Initial wiki pages")
-	runIn(t, workDir, "git", "push", "origin", "HEAD")
+	runIn(t, workDir, "git", "push", "origin", "HEAD:main")
 
 	return "file://" + bareDir
 }
@@ -241,7 +242,7 @@ func TestGitHubWikiScanDeletion(t *testing.T) {
 	workDir := filepath.Join(base, "work")
 
 	// Create bare repo with two files.
-	run(t, "git", "init", "--bare", bareDir)
+	run(t, "git", "init", "--bare", "--initial-branch=main", bareDir)
 	run(t, "git", "clone", bareDir, workDir)
 	runIn(t, workDir, "git", "config", "user.email", "test@test.com")
 	runIn(t, workDir, "git", "config", "user.name", "Test")
@@ -250,7 +251,7 @@ func TestGitHubWikiScanDeletion(t *testing.T) {
 	writeFile(t, workDir, "Extra.md", "# Extra")
 	runIn(t, workDir, "git", "add", "-A")
 	runIn(t, workDir, "git", "commit", "-m", "two pages")
-	runIn(t, workDir, "git", "push", "origin", "HEAD")
+	runIn(t, workDir, "git", "push", "origin", "HEAD:main")
 
 	repoURL := strings.TrimSuffix("file://"+bareDir, ".wiki.git")
 	c := NewGitHubWikiConnector(repoURL, "", "")
@@ -273,7 +274,7 @@ func TestGitHubWikiScanDeletion(t *testing.T) {
 	os.Remove(filepath.Join(workDir, "Extra.md"))
 	runIn(t, workDir, "git", "add", "-A")
 	runIn(t, workDir, "git", "commit", "-m", "remove Extra")
-	runIn(t, workDir, "git", "push", "origin", "HEAD")
+	runIn(t, workDir, "git", "push", "origin", "HEAD:main")
 
 	// Second scan — should detect deletion.
 	_, deleted, err := c.Scan(context.Background(), ScanOptions{Known: known})

--- a/internal/embedding/ollama.go
+++ b/internal/embedding/ollama.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,6 +21,9 @@ const (
 	defaultOllamaModel     = "nomic-embed-text"
 	defaultOllamaDimension = 768
 	embCacheMaxSize        = 512
+
+	// Retry settings for empty embedding responses.
+	embedMaxRetries = 3
 )
 
 // embCacheEntry holds a cached embedding with its creation time for LRU eviction.
@@ -171,19 +175,80 @@ func (o *OllamaEmbedder) evictOldest() {
 	}
 }
 
+// truncateForLog returns the first 100 characters of s for use in log messages.
+func truncateForLog(s string) string {
+	if len(s) <= 100 {
+		return s
+	}
+	return s[:100] + "..."
+}
+
+// isEmptyOrWhitespace reports whether s is empty or contains only whitespace.
+func isEmptyOrWhitespace(s string) bool {
+	return strings.TrimSpace(s) == ""
+}
+
+// embedWithRetry calls doEmbed and retries up to embedMaxRetries times when
+// Ollama returns 0 embeddings. Backoff intervals: 100ms, 500ms, 2s.
+func (o *OllamaEmbedder) embedWithRetry(ctx context.Context, input any) ([][]float32, error) {
+	backoffs := []time.Duration{100 * time.Millisecond, 500 * time.Millisecond, 2 * time.Second}
+
+	vectors, err := o.doEmbed(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	if len(vectors) > 0 {
+		return vectors, nil
+	}
+
+	// Log the input that produced an empty response.
+	inputSnippet := ""
+	switch v := input.(type) {
+	case string:
+		inputSnippet = truncateForLog(v)
+	case []string:
+		if len(v) > 0 {
+			inputSnippet = truncateForLog(v[0])
+		}
+	}
+	slog.Warn("ollama returned 0 embeddings, retrying", "input_preview", inputSnippet)
+
+	for attempt := 0; attempt < embedMaxRetries; attempt++ {
+		wait := backoffs[attempt]
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+
+		vectors, err = o.doEmbed(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		if len(vectors) > 0 {
+			slog.Info("ollama embed retry succeeded", "attempt", attempt+1)
+			return vectors, nil
+		}
+		slog.Warn("ollama embed retry still returned 0 embeddings", "attempt", attempt+1)
+	}
+
+	return nil, fmt.Errorf("response contained no embeddings after %d retries", embedMaxRetries)
+}
+
 // Embed returns the embedding vector for a single text.
 func (o *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	if isEmptyOrWhitespace(text) {
+		return nil, fmt.Errorf("ollama embed: input text is empty or whitespace-only")
+	}
+
 	key := embCacheKey(text)
 	if cached := o.cacheGet(key); cached != nil {
 		return cached, nil
 	}
 
-	vectors, err := o.doEmbed(ctx, text)
+	vectors, err := o.embedWithRetry(ctx, text)
 	if err != nil {
 		return nil, fmt.Errorf("ollama embed: %w", err)
-	}
-	if len(vectors) == 0 {
-		return nil, fmt.Errorf("ollama embed: response contained no embeddings")
 	}
 
 	o.cachePut(key, vectors[0])
@@ -202,6 +267,11 @@ func (o *OllamaEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]fl
 	var uncachedIndices []int
 
 	for i, text := range texts {
+		if isEmptyOrWhitespace(text) {
+			slog.Warn("skipping empty/whitespace-only text in batch", "index", i)
+			results[i] = nil
+			continue
+		}
 		key := embCacheKey(text)
 		if cached := o.cacheGet(key); cached != nil {
 			results[i] = cached
@@ -221,16 +291,16 @@ func (o *OllamaEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]fl
 	if len(uncachedTexts) == 1 {
 		input = uncachedTexts[0]
 	}
-	vectors, err := o.doEmbed(ctx, input)
+	vectors, err := o.embedWithRetry(ctx, input)
 	if err != nil {
 		// Batch request failed — fall back to embedding one-at-a-time so that
 		// a single oversized text doesn't fail the entire batch.
 		slog.Warn("batch embed failed, falling back to individual requests", "error", err, "count", len(uncachedTexts))
 		vectors = make([][]float32, len(uncachedTexts))
 		for i, text := range uncachedTexts {
-			vec, singleErr := o.doEmbed(ctx, text)
+			vec, singleErr := o.embedWithRetry(ctx, text)
 			if singleErr != nil {
-				slog.Warn("skipping text that failed to embed", "error", singleErr, "text_length", len(text))
+				slog.Warn("skipping text that failed to embed", "error", singleErr, "text_length", len(text), "input_preview", truncateForLog(text))
 				vectors[i] = nil
 			} else if len(vec) > 0 {
 				vectors[i] = vec[0]

--- a/internal/embedding/ollama_test.go
+++ b/internal/embedding/ollama_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -358,6 +359,127 @@ func TestEmbedBatch_FallbackOnBatchError(t *testing.T) {
 	// "too_long" should have a nil embedding.
 	if vecs[1] != nil {
 		t.Fatalf("expected nil embedding for 'too_long', got %v", vecs[1])
+	}
+}
+
+func TestEmbed_EmptyInput(t *testing.T) {
+	e := NewOllamaEmbedder("http://localhost:11434", "", 0, nil)
+
+	for _, input := range []string{"", "   ", "\t\n"} {
+		_, err := e.Embed(context.Background(), input)
+		if err == nil {
+			t.Errorf("Embed(%q) should return error for empty/whitespace input", input)
+		}
+		if !strings.Contains(err.Error(), "empty or whitespace") {
+			t.Errorf("error should mention empty/whitespace, got: %s", err.Error())
+		}
+	}
+}
+
+func TestEmbed_RetryOnZeroEmbeddings(t *testing.T) {
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		var resp ollamaEmbedResponse
+		if n <= 2 {
+			// First two calls return 0 embeddings.
+			resp = ollamaEmbedResponse{Model: "nomic-embed-text", Embeddings: [][]float64{}}
+		} else {
+			// Third call succeeds.
+			resp = ollamaEmbedResponse{Model: "nomic-embed-text", Embeddings: [][]float64{{0.1, 0.2}}}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	e := NewOllamaEmbedder(srv.URL, "", 2, nil)
+	vec, err := e.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Embed() should succeed after retry, got: %v", err)
+	}
+	if len(vec) != 2 {
+		t.Fatalf("expected 2-dim vector, got %d", len(vec))
+	}
+	// 1 initial + 2 retries = 3 calls
+	if callCount.Load() != 3 {
+		t.Errorf("expected 3 server calls (1 initial + 2 retries), got %d", callCount.Load())
+	}
+}
+
+func TestEmbed_RetryExhausted(t *testing.T) {
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		// Always return 0 embeddings.
+		resp := ollamaEmbedResponse{Model: "nomic-embed-text", Embeddings: [][]float64{}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	e := NewOllamaEmbedder(srv.URL, "", 2, nil)
+	_, err := e.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("Embed() should fail after all retries exhausted")
+	}
+	if !strings.Contains(err.Error(), "no embeddings after") {
+		t.Errorf("error should mention retries, got: %s", err.Error())
+	}
+	// 1 initial + 3 retries = 4 calls
+	if callCount.Load() != 4 {
+		t.Errorf("expected 4 server calls (1 initial + 3 retries), got %d", callCount.Load())
+	}
+}
+
+func TestEmbedBatch_SkipsEmptyTexts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		// Should only receive the non-empty text.
+		resp := ollamaEmbedResponse{
+			Model:      "nomic-embed-text",
+			Embeddings: [][]float64{{0.5, 0.6}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	e := NewOllamaEmbedder(srv.URL, "", 2, nil)
+	vecs, err := e.EmbedBatch(context.Background(), []string{"hello", "", "  "})
+	if err != nil {
+		t.Fatalf("EmbedBatch() error: %v", err)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("expected 3 result slots, got %d", len(vecs))
+	}
+	if vecs[0] == nil {
+		t.Fatal("expected non-nil embedding for 'hello'")
+	}
+	if vecs[1] != nil {
+		t.Errorf("expected nil for empty string, got %v", vecs[1])
+	}
+	if vecs[2] != nil {
+		t.Errorf("expected nil for whitespace string, got %v", vecs[2])
+	}
+}
+
+func TestTruncateForLog(t *testing.T) {
+	short := "hello"
+	if got := truncateForLog(short); got != "hello" {
+		t.Errorf("truncateForLog(%q) = %q, want %q", short, got, "hello")
+	}
+
+	long := strings.Repeat("a", 200)
+	got := truncateForLog(long)
+	if len(got) != 103 { // 100 + "..."
+		t.Errorf("truncateForLog(200 chars) length = %d, want 103", len(got))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("truncateForLog should end with '...', got: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #10. Closes #15.

Addresses the intermittent `ollama embed batch: expected 1 embeddings, got 0` error by:

1. **Skipping empty/whitespace-only input** before sending to Ollama
2. **Retry with exponential backoff** (100ms, 500ms, 2s) when Ollama returns 0 embeddings
3. **Logging failed input** (first 100 chars) at warn level for debugging

Also fixes the flaky `TestGitHubWikiScan*` tests (#15) by setting `--initial-branch=main` on bare repo creation.

## Test plan

- [x] `make test` — all tests pass (including new retry tests and previously-flaky wiki tests)
- [x] New tests: empty input rejection, retry behavior, retry exhaustion, batch empty-text skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)