### PR TITLE
Move confidence scoring and metadata out of LLM synthesis

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -148,8 +149,8 @@ func (m *MockConnector) Scan(_ context.Context, opts connector.ScanOptions) ([]m
 // MockLLM
 // ---------------------------------------------------------------------------
 
-// MockLLM satisfies query.LLM and returns a canned response that includes
-// the KB_META JSON block.
+// MockLLM satisfies query.LLM and returns a canned response.
+// It includes a legacy KB_META block to verify backward-compat stripping.
 type MockLLM struct{}
 
 var _ query.LLM = (*MockLLM)(nil)
@@ -338,10 +339,14 @@ func RetryWithBackoff(attempts int, fn func() error) error {
 		t.Fatal("expected streamed text, got empty string")
 	}
 	if answer.Confidence.Breakdown.Freshness == 0 && answer.Confidence.Breakdown.Consistency == 0 {
-		t.Fatal("expected confidence signals to be parsed from KB_META block")
+		t.Fatal("expected server-computed confidence signals to be non-zero")
 	}
 	if answer.Confidence.Overall == 0 {
-		t.Fatal("expected overall confidence to be parsed from KB_META block")
+		t.Fatal("expected server-computed overall confidence to be non-zero")
+	}
+	// Legacy KB_META block should be stripped from the content.
+	if strings.Contains(answer.Content, "KB_META") {
+		t.Fatal("expected KB_META block to be stripped from answer content")
 	}
 	t.Logf("Answer (first 100 chars): %.100s", answer.Content)
 	t.Logf("Confidence: overall=%.2f freshness=%.2f corroboration=%.2f consistency=%.2f authority=%.2f",

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -2,11 +2,11 @@ package query
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"math"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -271,8 +271,8 @@ func (e *Engine) Query(ctx context.Context, req model.QueryRequest, onText func(
 		return nil, fmt.Errorf("llm synthesis: %w", err)
 	}
 
-	// Parse the response for metadata.
-	answer := parseResponse(fullResponse, fragments)
+	// Build the answer with server-computed confidence and sources.
+	answer := buildAnswer(fullResponse, fragments)
 
 	// Cache the result.
 	e.cache.Put(lastMsg.Content, req.Concise, fragments, answer, ctx)
@@ -281,51 +281,123 @@ func (e *Engine) Query(ctx context.Context, req model.QueryRequest, onText func(
 	return answer, nil
 }
 
-const metaStart = "---KB_META---"
-const metaEnd = "---KB_META_END---"
+// citationRe matches [fragment_id] citations in LLM prose.
+var citationRe = regexp.MustCompile(`\[([a-f0-9]{8,})\]`)
 
-// parseResponse extracts the answer text and metadata JSON from the LLM response.
-func parseResponse(response string, fragments []model.SourceFragment) *model.Answer {
-	answer := &model.Answer{
-		Content: response,
-		Sources: make([]model.SourceRef, 0, len(fragments)),
+// parseCitations extracts fragment IDs cited in the LLM prose text.
+func parseCitations(text string) []string {
+	matches := citationRe.FindAllStringSubmatch(text, -1)
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, m := range matches {
+		id := m[1]
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// computeConfidence computes server-side confidence from the given fragments,
+// using the same logic as QueryRaw.
+func computeConfidence(fragments []model.SourceFragment) model.Confidence {
+	// Count distinct source names for corroboration.
+	sourceNames := make(map[string]struct{})
+	for _, f := range fragments {
+		sourceNames[f.SourceName] = struct{}{}
+	}
+	corroboration := ComputeCorroboration(len(sourceNames))
+
+	// Average per-fragment signals.
+	var freshness, consistency, authority float64
+	for _, f := range fragments {
+		freshness += ComputeFreshness(f.ContentDate, f.IngestedAt, f.FileType)
+		consistency += ComputeConsistency(f.ConfidenceAdj)
+		authority += ComputeAuthority(f.FileType)
+	}
+	n := float64(len(fragments))
+	if n > 0 {
+		freshness /= n
+		consistency /= n
+		authority /= n
 	}
 
-	// Try to extract the metadata block.
-	startIdx := strings.LastIndex(response, metaStart)
-	endIdx := strings.LastIndex(response, metaEnd)
+	breakdown := model.ConfidenceBreakdown{
+		Freshness:     math.Round(freshness*100) / 100,
+		Corroboration: corroboration,
+		Consistency:   math.Round(consistency*100) / 100,
+		Authority:     math.Round(authority*100) / 100,
+	}
 
-	if startIdx >= 0 && endIdx > startIdx {
-		jsonStr := strings.TrimSpace(response[startIdx+len(metaStart) : endIdx])
-		answer.Content = strings.TrimSpace(response[:startIdx])
+	return model.Confidence{
+		Overall:   ComputeOverallTrust(breakdown, model.DefaultTrustWeights()),
+		Breakdown: breakdown,
+	}
+}
 
-		var meta struct {
-			Confidence     model.Confidence      `json:"confidence"`
-			Sources        []model.SourceRef     `json:"sources"`
-			Contradictions []model.Contradiction `json:"contradictions"`
-		}
-		if err := json.Unmarshal([]byte(jsonStr), &meta); err == nil {
-			answer.Confidence = meta.Confidence
-			if len(meta.Sources) > 0 {
-				answer.Sources = meta.Sources
+// buildAnswer constructs an Answer from the LLM prose and retrieved fragments.
+// Confidence is computed server-side. Sources are derived from cited fragments
+// when citations are present, otherwise from all retrieved fragments.
+// If the LLM response contains a legacy ---KB_META--- block, it is stripped.
+func buildAnswer(response string, fragments []model.SourceFragment) *model.Answer {
+	// Strip legacy metadata block if present (backward compat).
+	content := response
+	if startIdx := strings.LastIndex(content, "---KB_META---"); startIdx >= 0 {
+		content = strings.TrimSpace(content[:startIdx])
+	}
+
+	// Parse citations from LLM prose.
+	cited := parseCitations(content)
+
+	// Build a lookup of retrieved fragments by ID.
+	fragByID := make(map[string]model.SourceFragment, len(fragments))
+	for _, f := range fragments {
+		fragByID[f.ID] = f
+	}
+
+	// Build sources list from cited fragments if any, else all fragments.
+	var sources []model.SourceRef
+	var confidenceFragments []model.SourceFragment
+	if len(cited) > 0 {
+		seen := make(map[string]struct{})
+		for _, id := range cited {
+			if f, ok := fragByID[id]; ok {
+				if _, dup := seen[id]; !dup {
+					seen[id] = struct{}{}
+					sources = append(sources, model.SourceRef{
+						FragmentID: f.ID,
+						SourceURI:  f.SourceURI,
+						SourcePath: f.SourcePath,
+						SourceName: f.SourceName,
+					})
+					confidenceFragments = append(confidenceFragments, f)
+				}
 			}
-			answer.Contradictions = meta.Contradictions
 		}
 	}
 
-	// If no sources from metadata, include all retrieved fragments as sources.
-	if len(answer.Sources) == 0 {
+	// Fall back to all retrieved fragments if no valid citations found.
+	if len(sources) == 0 {
 		for _, f := range fragments {
-			answer.Sources = append(answer.Sources, model.SourceRef{
+			sources = append(sources, model.SourceRef{
 				FragmentID: f.ID,
 				SourceURI:  f.SourceURI,
 				SourcePath: f.SourcePath,
 				SourceName: f.SourceName,
 			})
 		}
+		confidenceFragments = fragments
 	}
 
-	return answer
+	// Compute confidence server-side from the fragments.
+	confidence := computeConfidence(confidenceFragments)
+
+	return &model.Answer{
+		Content:    content,
+		Confidence: confidence,
+		Sources:    sources,
+	}
 }
 
 // combineEmbeddings blends two embedding vectors: result = normalize(a + b * weight).

--- a/internal/query/engine_test.go
+++ b/internal/query/engine_test.go
@@ -2,7 +2,9 @@ package query
 
 import (
 	"math"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/knowledge-broker/knowledge-broker/pkg/model"
 )
@@ -67,5 +69,168 @@ func TestCombineEmbeddings_ShiftsDirection(t *testing.T) {
 	// The x component should still dominate since weight < 1.
 	if combined[0] <= combined[1] {
 		t.Fatalf("expected x > y since weight is 0.3, got x=%f y=%f", combined[0], combined[1])
+	}
+}
+
+func TestParseCitations(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "no citations",
+			text: "This is plain text with no citations.",
+			want: nil,
+		},
+		{
+			name: "single citation",
+			text: "The retry logic uses backoff [abc12345].",
+			want: []string{"abc12345"},
+		},
+		{
+			name: "multiple citations",
+			text: "Found in [abc12345] and confirmed by [def67890].",
+			want: []string{"abc12345", "def67890"},
+		},
+		{
+			name: "duplicate citations",
+			text: "See [abc12345] and also [abc12345] again.",
+			want: []string{"abc12345"},
+		},
+		{
+			name: "16-char hex id",
+			text: "Source [abcdef0123456789] confirms this.",
+			want: []string{"abcdef0123456789"},
+		},
+		{
+			name: "short id ignored",
+			text: "Not a citation [abc].",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCitations(tt.text)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseCitations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func testFragments() []model.SourceFragment {
+	now := time.Now()
+	return []model.SourceFragment{
+		{
+			ID:          "abcdef0123456789",
+			RawContent:  "fragment one content",
+			SourceType:  "filesystem",
+			SourceName:  "project-a",
+			SourcePath:  "/docs/readme.md",
+			SourceURI:   "file:///docs/readme.md",
+			ContentDate: now.Add(-24 * time.Hour),
+			IngestedAt:  now.Add(-1 * time.Hour),
+			FileType:    ".md",
+		},
+		{
+			ID:          "1234567890abcdef",
+			RawContent:  "fragment two content",
+			SourceType:  "github",
+			SourceName:  "project-b",
+			SourcePath:  "src/main.go",
+			SourceURI:   "https://github.com/org/repo/blob/main/src/main.go",
+			ContentDate: now.Add(-48 * time.Hour),
+			IngestedAt:  now.Add(-2 * time.Hour),
+			FileType:    ".go",
+		},
+	}
+}
+
+func TestBuildAnswer_PlainText(t *testing.T) {
+	frags := testFragments()
+	response := "The answer is X [abcdef0123456789] and Y [1234567890abcdef]."
+	answer := buildAnswer(response, frags)
+
+	if answer.Content != response {
+		t.Errorf("expected content to be unchanged, got %q", answer.Content)
+	}
+	if answer.Confidence.Overall == 0 {
+		t.Error("expected non-zero overall confidence")
+	}
+	if answer.Confidence.Breakdown.Freshness == 0 {
+		t.Error("expected non-zero freshness")
+	}
+	if len(answer.Sources) != 2 {
+		t.Errorf("expected 2 sources from citations, got %d", len(answer.Sources))
+	}
+}
+
+func TestBuildAnswer_NoCitations_FallsBackToAllFragments(t *testing.T) {
+	frags := testFragments()
+	response := "The answer is based on the available documents."
+	answer := buildAnswer(response, frags)
+
+	if len(answer.Sources) != len(frags) {
+		t.Errorf("expected %d sources (all fragments), got %d", len(frags), len(answer.Sources))
+	}
+}
+
+func TestBuildAnswer_StripsLegacyMeta(t *testing.T) {
+	frags := testFragments()
+	response := `The answer is X.
+
+---KB_META---
+{"confidence":{"overall":0.84,"breakdown":{"freshness":0.9,"corroboration":0.8,"consistency":0.95,"authority":0.7}},"sources":[],"contradictions":[]}
+---KB_META_END---`
+
+	answer := buildAnswer(response, frags)
+
+	if answer.Content != "The answer is X." {
+		t.Errorf("expected legacy meta stripped, got %q", answer.Content)
+	}
+	// Confidence should be server-computed, not from the legacy block.
+	if answer.Confidence.Overall == 0 {
+		t.Error("expected non-zero server-computed confidence")
+	}
+}
+
+func TestBuildAnswer_CitedSubsetOnly(t *testing.T) {
+	frags := testFragments()
+	// Only cite the first fragment.
+	response := "The answer is X [abcdef0123456789]."
+	answer := buildAnswer(response, frags)
+
+	if len(answer.Sources) != 1 {
+		t.Fatalf("expected 1 source from citation, got %d", len(answer.Sources))
+	}
+	if answer.Sources[0].FragmentID != "abcdef0123456789" {
+		t.Errorf("expected cited fragment, got %q", answer.Sources[0].FragmentID)
+	}
+}
+
+func TestComputeConfidence(t *testing.T) {
+	frags := testFragments()
+	conf := computeConfidence(frags)
+
+	if conf.Overall == 0 {
+		t.Error("expected non-zero overall confidence")
+	}
+	if conf.Breakdown.Freshness == 0 {
+		t.Error("expected non-zero freshness")
+	}
+	if conf.Breakdown.Corroboration == 0 {
+		t.Error("expected non-zero corroboration")
+	}
+	if conf.Breakdown.Consistency == 0 {
+		t.Error("expected non-zero consistency")
+	}
+	if conf.Breakdown.Authority == 0 {
+		t.Error("expected non-zero authority")
+	}
+	// Two different source names = corroboration 0.6.
+	if conf.Breakdown.Corroboration != 0.6 {
+		t.Errorf("expected corroboration 0.6 for 2 sources, got %v", conf.Breakdown.Corroboration)
 	}
 }

--- a/internal/query/prompt.go
+++ b/internal/query/prompt.go
@@ -20,17 +20,9 @@ func BuildSystemPrompt(fragments []model.SourceFragment, concise bool) string {
 RULES:
 - Be maximally terse. No filler, no caveats, no preamble. Use abbreviations.
 - State facts directly. "Retries 3x, exp backoff, 1s initial" not "The service retries failed charges up to three times using exponential backoff with an initial delay of one second."
-- Cite sources inline as [id].
+- Cite sources inline as [fragment_id].
 - If sources contradict, state both claims briefly. Include the date of each source to indicate which is newer. Example: 'Source A (2025-11-03) says X, but Source B (2026-02-15) says Y — the newer source likely supersedes.'
-
-Emit metadata after your answer:
-
----KB_META---
-{"confidence":{"overall":0.0,"breakdown":{"freshness":0.0,"corroboration":0.0,"consistency":0.0,"authority":0.0}},"sources":[{"fragment_id":"...","source_uri":"...","source_path":"..."}],"contradictions":[]}
----KB_META_END---
-
-Confidence breakdown: freshness=recency relative to corpus (code files are always fresh as long as they exist in the corpus; for documentation and prose, score freshness based on recency), corroboration=number of independent sources (1=0.3,2-3=0.6,4+=0.9), consistency=agreement between sources, authority=source type fitness (code>docs>config>commits). Compute overall as a weighted composite: freshness*0.20 + corroboration*0.25 + consistency*0.30 + authority*0.25.
-Only include fragments you used in sources. No text after ---KB_META_END---. No code fences around the metadata block.
+- Do NOT produce any JSON or structured metadata. Just write your answer.
 
 If fragments come from multiple unrelated projects, answer based on the most relevant project and note which project you're answering about. Do not blend information from unrelated projects into a single answer.
 
@@ -42,35 +34,13 @@ You have been given a set of source fragments retrieved from a knowledge base. Y
 
 1. Synthesise a clear, accurate answer from the fragments
 2. Cite sources inline using [fragment_id] notation
-3. Assess confidence signals for your answer
-4. Flag any contradictions between sources
-
-## Confidence signals
-
-Assess these four signals on a scale of 0.0 to 1.0:
-
-- **Freshness**: Code files (source code, config) are always fresh as long as they exist in the corpus. For documentation and prose, score freshness based on recency relative to the range of dates you see.
-- **Corroboration**: How many independent sources support the answer? 1 source = low (0.2-0.4), 2-3 sources = medium (0.5-0.7), 4+ sources = high (0.8-1.0).
-- **Consistency**: Do the sources agree? If they contradict each other, score lower and flag the contradiction.
-- **Authority**: How authoritative are the source types for this kind of question? Code is authoritative for behaviour. Docs are authoritative for intent/design. Config files are authoritative for settings. Commit messages are low authority.
+3. Note any contradictions between sources in natural language
 
 When sources contradict, include the date of each source to indicate which is newer. Example: 'Source A (2025-11-03) says X, but Source B (2026-02-15) says Y — the newer source likely supersedes.'
 
-## Response format
+Write your answer in natural language. Be direct and concise. Cite sources inline like [abc123].
 
-First, write your answer in natural language. Be direct and concise. Cite sources inline like [abc123].
-
-Then, on a new line, emit a metadata block in exactly this format:
-
----KB_META---
-{"confidence":{"overall":0.0,"breakdown":{"freshness":0.0,"corroboration":0.0,"consistency":0.0,"authority":0.0}},"sources":[{"fragment_id":"...","source_uri":"...","source_path":"..."}],"contradictions":[]}
----KB_META_END---
-
-The "overall" score is a weighted composite: freshness*0.20 + corroboration*0.25 + consistency*0.30 + authority*0.25.
-The sources array should include only the fragments you actually used in your answer.
-If there are contradictions, include them with claim, sources, and explanation fields.
-Do NOT include any text after the ---KB_META_END--- marker.
-Do NOT wrap the metadata block in code fences or backticks.
+Do NOT produce any JSON or structured metadata. Just write your answer.
 
 If fragments come from multiple unrelated projects, answer based on the most relevant project and note which project you're answering about. Do not blend information from unrelated projects into a single answer.
 

--- a/internal/query/prompt_test.go
+++ b/internal/query/prompt_test.go
@@ -17,8 +17,13 @@ func TestBuildSystemPrompt_NoFragments(t *testing.T) {
 	if !strings.Contains(prompt, "Knowledge Broker") {
 		t.Error("prompt should mention Knowledge Broker")
 	}
-	if !strings.Contains(prompt, "KB_META") {
-		t.Error("prompt should contain KB_META instruction")
+	// Should NOT contain structured metadata instructions
+	if strings.Contains(prompt, "KB_META") {
+		t.Error("prompt should not contain KB_META instruction")
+	}
+	// Should instruct the LLM NOT to produce JSON, not ask it to emit JSON metadata.
+	if strings.Contains(prompt, "emit a metadata block") {
+		t.Error("prompt should not ask LLM to emit metadata block")
 	}
 	// Should have no fragment headers
 	if strings.Contains(prompt, "### Fragment:") {
@@ -92,26 +97,27 @@ func TestBuildSystemPrompt_WithFragments(t *testing.T) {
 		t.Error("prompt should contain file type markdown")
 	}
 
-	// Should include structured output instructions
-	if !strings.Contains(prompt, "---KB_META---") {
-		t.Error("prompt should contain KB_META start delimiter")
+	// Should NOT include structured metadata instructions
+	if strings.Contains(prompt, "---KB_META---") {
+		t.Error("prompt should not contain KB_META start delimiter")
 	}
-	if !strings.Contains(prompt, "---KB_META_END---") {
-		t.Error("prompt should contain KB_META end delimiter")
+	if strings.Contains(prompt, "---KB_META_END---") {
+		t.Error("prompt should not contain KB_META end delimiter")
 	}
 
-	// Should include confidence signal instructions
-	if !strings.Contains(prompt, "Freshness") {
-		t.Error("prompt should explain freshness signal")
+	// Should include citation instructions
+	if !strings.Contains(prompt, "[fragment_id]") {
+		t.Error("prompt should explain citation notation")
 	}
-	if !strings.Contains(prompt, "Corroboration") {
-		t.Error("prompt should explain corroboration signal")
+
+	// Should mention contradictions
+	if !strings.Contains(prompt, "contradict") {
+		t.Error("prompt should mention contradictions")
 	}
-	if !strings.Contains(prompt, "Consistency") {
-		t.Error("prompt should explain consistency signal")
-	}
-	if !strings.Contains(prompt, "Authority") {
-		t.Error("prompt should explain authority signal")
+
+	// Should NOT ask for confidence scoring
+	if strings.Contains(prompt, "Corroboration") {
+		t.Error("prompt should not explain corroboration signal")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #26.

Confidence scores are now computed server-side for both synthesis and raw modes, using the same `Compute*` functions. The LLM prompt is simplified to just synthesis + citation + contradiction detection — no more asking the model to hallucinate scores or emit structured JSON.

### Before
- LLM computed confidence scores (hallucinated, not following the actual formulas)
- LLM emitted `---KB_META---` JSON block with scores, sources, contradictions
- Scores differed between `--raw` and synthesis modes

### After
- Server computes confidence identically in both modes
- LLM just writes a natural-language answer with `[fragment_id]` citations
- Sources extracted from citations (falls back to all retrieved fragments)
- Simpler prompt, fewer tokens, unblocks local LLM synthesis

## Changes

- `internal/query/prompt.go` — Simplified system prompt, removed KB_META format
- `internal/query/engine.go` — `parseCitations()`, `computeConfidence()`, `buildAnswer()`, legacy KB_META stripping
- Tests updated for new prompt and response handling

## Test plan

- [x] `make test` — all pass
- [ ] Manual: compare `kb query` vs `kb query --raw` confidence scores for same query — should now match
- [ ] Manual: verify synthesis answers still cite sources and mention contradictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)